### PR TITLE
Fix concurrency issue with NSImage in task

### DIFF
--- a/window previews.swift
+++ b/window previews.swift
@@ -463,12 +463,10 @@ class PreviewWindow: NSWindow {
         setPlaceholderImage()
         
         if #available(macOS 12.3, *), let recorder = screenRecorder {
-            Task {
+            Task { @MainActor [weak self] in
                 let image = await recorder.captureWindow(for: app)
-                DispatchQueue.main.async { [weak self] in
-                    if let image = image {
-                        self?.imageView.image = image
-                    }
+                if let image = image {
+                    self?.imageView.image = image
                 }
             }
         }
@@ -506,8 +504,9 @@ class PreviewWindow: NSWindow {
 
 // MARK: - Screen Recorder
 @available(macOS 12.3, *)
+@MainActor
 class ScreenRecorder: Sendable {
-    
+
     func captureWindow(for app: AppInfo) async -> NSImage? {
         do {
             let content = try await SCShareableContent.excludingDesktopWindows(false, onScreenWindowsOnly: true)


### PR DESCRIPTION
## Summary
- run screenshot capturing on the main actor
- mark the screen recorder as `@MainActor`

## Testing
- `swiftc 'window previews.swift' -o /tmp/out || true` *(fails: no such module 'Cocoa')*

------
https://chatgpt.com/codex/tasks/task_e_6881a6ff8bdc83329321c4d45fee7b60