### PR TITLE
Modify permission workflow

### DIFF
--- a/Tester/DockPreviews/Sources/DockPreviews/DockPreviewsApp.swift
+++ b/Tester/DockPreviews/Sources/DockPreviews/DockPreviewsApp.swift
@@ -23,8 +23,8 @@ struct DockPreviewsApp: App {
     }
 
     init() {
-        // Check permissions on app launch
-        let permissionsGranted = PermissionsManager.checkAndRequestPermissions()
+        // Only check permission status on launch without prompting the user
+        let permissionsGranted = PermissionsManager.checkPermissions()
         if permissionsGranted {
             self.dockMonitor = DockMonitor()
         } else {

--- a/Tester/DockPreviews/Sources/DockPreviews/PermissionsManager.swift
+++ b/Tester/DockPreviews/Sources/DockPreviews/PermissionsManager.swift
@@ -4,12 +4,11 @@ import AppKit
 import CoreGraphics
 
 class PermissionsManager {
-    static func checkAndRequestPermissions() -> Bool {
+    /// Checks the current permission status without prompting the user.
+    static func checkPermissions() -> Bool {
         let status = permissionsStatus()
         print("Current Permissions Status: \(status)")
-        let accessibilityGranted = checkAccessibilityPermissions()
-        checkScreenRecordingPermissions()
-        return accessibilityGranted
+        return status["Accessibility"] ?? false
     }
 
     static func permissionsStatus() -> [String: Bool] {
@@ -27,32 +26,23 @@ class PermissionsManager {
     }
 
     static func manuallyRequestPermissions() {
+        requestAccessibilityPermission()
+        requestScreenRecordingPermission()
+    }
+
+    static func requestAccessibilityPermission() {
         openAccessibilitySettings()
+    }
+
+    static func requestScreenRecordingPermission() {
+        if #available(macOS 10.15, *) {
+            CGRequestScreenCaptureAccess()
+        }
         openScreenRecordingSettings()
     }
 
-    private static func checkAccessibilityPermissions() -> Bool {
-        let accessEnabled = AXIsProcessTrusted()
-
-        if !accessEnabled {
-            print("Accessibility access NOT granted. Please go to System Settings -> Privacy & Security -> Accessibility and ensure 'DockPreviews' (or 'Xcode' if running from there) is checked.")
-            openAccessibilitySettings()
-        } else {
-            print("Accessibility access GRANTED.")
-        }
-        return accessEnabled
-    }
-
-    private static func checkScreenRecordingPermissions() {
-        if #available(macOS 10.15, *) {
-            if !CGPreflightScreenCaptureAccess() {
-                print("Screen Recording access NOT granted. Requesting access...")
-                CGRequestScreenCaptureAccess()
-            } else {
-                print("Screen Recording access GRANTED.")
-            }
-        }
-    }
+    // These methods are kept private as helpers for opening the relevant
+    // System Settings panes.
 
     private static func openAccessibilitySettings() {
         if let url = URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility") {

--- a/Tester/DockPreviews/Sources/DockPreviews/SettingsView.swift
+++ b/Tester/DockPreviews/Sources/DockPreviews/SettingsView.swift
@@ -5,9 +5,40 @@ struct SettingsView: View {
     @State private var animationSpeed = 0.5
     @State private var previewResolution = 1.0
     @State private var filteredApps = "java"
+    @State private var accessibilityGranted = false
+    @State private var screenRecordingGranted = false
+
+    private func refreshPermissions() {
+        let status = PermissionsManager.permissionsStatus()
+        accessibilityGranted = status["Accessibility"] ?? false
+        screenRecordingGranted = status["Screen Recording"] ?? false
+    }
 
     var body: some View {
         Form {
+            Section(header: Text("Permissions")) {
+                HStack {
+                    Text(accessibilityGranted ? "Accessibility: Granted" : "Accessibility: Not Granted")
+                        .foregroundColor(accessibilityGranted ? .green : .red)
+                    Spacer()
+                    Button("Grant") {
+                        PermissionsManager.requestAccessibilityPermission()
+                        refreshPermissions()
+                    }
+                }
+                HStack {
+                    Text(screenRecordingGranted ? "Screen Recording: Granted" : "Screen Recording: Not Granted")
+                        .foregroundColor(screenRecordingGranted ? .green : .red)
+                    Spacer()
+                    Button("Grant") {
+                        PermissionsManager.requestScreenRecordingPermission()
+                        refreshPermissions()
+                    }
+                }
+                Button("Refresh") {
+                    refreshPermissions()
+                }
+            }
             Section(header: Text("General")) {
                 Slider(value: $animationSpeed, in: 0.1...2.0) {
                     Text("Animation Speed")
@@ -21,5 +52,8 @@ struct SettingsView: View {
             }
         }
         .padding()
+        .onAppear {
+            refreshPermissions()
+        }
     }
 }


### PR DESCRIPTION
## Summary
- don't prompt for permissions automatically on launch
- refresh permission status in settings and allow requesting from there
- add color indicators for permission status

## Testing
- `swift build -c release` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_6881bf257f2c833297de1e62ab35cd7f