### PR TITLE
Fix debug log path and screen recording detection

### DIFF
--- a/WindowPreview/WindowPreview/AppDelegate.swift
+++ b/WindowPreview/WindowPreview/AppDelegate.swift
@@ -182,7 +182,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         
         info += "================================\n"
         info += "DEBUG LOG:\n"
-        let logPath = NSHomeDirectory() + "/Desktop/WindowPreview/debug.log"
+        // Match the path used by Logger.swift
+        let logPath = NSHomeDirectory() + "/Desktop/WindowPreview/logs/debug.log"
         if FileManager.default.fileExists(atPath: logPath) {
             do {
                 let logContent = try String(contentsOfFile: logPath)
@@ -244,9 +245,15 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     }
     
     private func isScreenRecordingEnabled() -> Bool {
-        if #available(macOS 10.15, *) {
-            let stream = CGDisplayStream(dispatchQueueDisplay: CGMainDisplayID(), outputWidth: 1, outputHeight: 1, pixelFormat: 1, properties: nil, queue: .main) { _, _, _, _ in }
-            return stream != nil
+        guard #available(macOS 10.15, *) else { return false }
+
+        // Check using CGWindowList to avoid unreliable CGDisplayStream checks
+        if let windowList = CGWindowListCopyWindowInfo(.optionAll, kCGNullWindowID) as? [[String: Any]] {
+            for window in windowList {
+                if let name = window[kCGWindowName as String] as? String, !name.isEmpty {
+                    return true
+                }
+            }
         }
         return false
     }

--- a/WindowPreview/WindowPreview/SettingsView.swift
+++ b/WindowPreview/WindowPreview/SettingsView.swift
@@ -42,9 +42,14 @@ struct SettingsView: View {
     }
     
     private func isScreenRecordingEnabled() -> Bool {
-        if #available(macOS 10.15, *) {
-            let stream = CGDisplayStream(dispatchQueueDisplay: CGMainDisplayID(), outputWidth: 1, outputHeight: 1, pixelFormat: 1, properties: nil, queue: .main) { _, _, _, _ in }
-            return stream != nil
+        guard #available(macOS 10.15, *) else { return false }
+
+        if let windowList = CGWindowListCopyWindowInfo(.optionAll, kCGNullWindowID) as? [[String: Any]] {
+            for window in windowList {
+                if let name = window[kCGWindowName as String] as? String, !name.isEmpty {
+                    return true
+                }
+            }
         }
         return false
     }


### PR DESCRIPTION
## Summary
- fix path to debug log in debug info generator
- fix screen recording permission check to use `CGWindowListCopyWindowInfo`
- update SettingsView's permission check accordingly

## Testing
- `python3 WindowPreview/test_launch.py` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6889bd7967b08332b2af4dd2aa666590